### PR TITLE
Update DelimitedInputFormatSamplingTest.java

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/common/io/DelimitedInputFormatSamplingTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/DelimitedInputFormatSamplingTest.java
@@ -288,7 +288,7 @@ public class DelimitedInputFormatSamplingTest {
 		}
 		
 		public static void prepare() {
-			DelimitedInputFormat.loadGloablConfigParams();
+			DelimitedInputFormat.loadGlobalConfigParams();
 		}
 	}
 }


### PR DESCRIPTION
typo in function name (also present in flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java)
